### PR TITLE
Add Matterbridge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM 42wim/matterbridge:1.22.3
-ADD matterbridge/matterbridge.toml .
-CMD ["/bin/matterbridge"]
+COPY ./matterbridge/matterbridge.toml .
+CMD [ "/bin/matterbridge" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM 42wim/matterbridge:1.22.3
+ADD matterbridge/matterbridge.toml .
+CMD ["/bin/matterbridge"]

--- a/Setup.md
+++ b/Setup.md
@@ -1,0 +1,49 @@
+# Discord <-> Matrix
+
+1. Discord
+
+After you complete [the tutorial](https://github.com/42wim/matterbridge/wiki/Discord-bot-setup), you will get 2 id: Bot token id and your server id.
+
+Remember add bot into server.
+
+Create one role for bot in Server settings -> Roles. Add your bot into this.
+
+Now you switch to Intergrations, create New Webhook, enter your bot name and save changes.
+
+In ```matterbridge.toml```, you need to change YOUR_BOT_TOKEN and YOUR_SERVER_ID. 
+
+2. Matrix
+
+You will create a new matrix account and use it as a middleman to transfer messages. 
+
+In ```matterbridge.toml```, you need to replace username (not email) and password with new account on the above.
+
+3. Gateway
+
+You need to replace your discord channel and matrix channel as you want to bridge.
+
+Example: https://app.element.io/#/room/#polkadot-watercooler:web3.foundation
+
+A matrix channel (both room name and home server) eg: #polkadot-watercooler:web3.foundation
+
+Note: if the home server you use is not ```matrix.org```, please replace YOUR_SERVER in ```matterbridge.toml```.
+
+4. Build docker image & upload it on docker hub
+
+Run ```docker build -t matterbridge .```
+
+Login at [hub.docker.com](https://hub.docker.com/). Create a new account if you don't have it.
+
+In your terminal, run ```docker login```.
+
+Run ```docker images```, you will see ```matterbridge``` repository you've created on the above.
+
+Run ```docker tag <YOUR_MATTERBRIDGE_IMAGE_ID> <YOUR_DOCKER_HUB_USERNAME>/matterbridge:latest```
+
+Run ```docker push <YOUR_DOCKER_HUB_USERNAME>/matterbridge```
+
+Note: In ```matterbridge-deployment.yaml```, you need to change YOUR_DOCKER_HUB_USERNAME.
+
+5. Deploy to Kubernetes.
+
+Run ```kubectl apply -f matterbridge-deployment.yaml```.

--- a/matterbridge-deployment.yaml
+++ b/matterbridge-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: 
+  name: matterbridge-deployment
+  labels:
+    app: matterbridge
+spec:  
+  replicas: 3  
+  selector: 
+    matchLabels:
+      app: matterbridge
+  template:    
+    metadata:      
+      labels:        
+        app: matterbridge    
+    spec:      
+      containers:      
+      - name: matterbridge  
+        image: YOUR_DOCKER_HUB_USERNAME/matterbridge

--- a/matterbridge/matterbridge.toml
+++ b/matterbridge/matterbridge.toml
@@ -1,0 +1,30 @@
+[discord]
+[discord.phala]
+Token="YOUR_DISCORD_BOT_TOKEN"
+Server="YOUR_DISCORD_SERVER_ID"
+UseUserName=true
+UseDiscriminator=true
+AutoWebhooks=true
+
+[matrix]
+[matrix.phala]
+#Server is your homeserver (eg https://matrix.org)
+Server="https://matrix.org"
+Login="YOUR_DEDICATED_ACCOUNT_USERNAME"
+Password="YOUR_DEDICATED_ACCOUNT_PASSWORD"
+
+[general]
+RemoteNickFormat="{NICK} "
+
+[[gateway]]
+    name = "mygateway"
+    enable=true
+
+    [[gateway.inout]]
+    account = "discord.phala"
+    channel="general"
+
+    [[gateway.inout]]
+    account = "matrix.phala"
+    channel="#YOUR_MATRIX_CHANNEL:YOUR_HOME_SERVER"
+


### PR DESCRIPTION
1. Research the proper software to bridge Matrix-Discrod bridge
- [x] Two way message bridging
- [ ] Can simulate the user name and avatar on the both side
- [x] Can be deployed to a Kubernetes cluster
- [ ] Can expose the basic monitoring metrics

2. Document the detailed deployment guide, including how to:
- [x] set up the bot accounts
- [x] config the software
- [ ] deploy to production

I can't create ```@__discord__``` because it runs on synapse. You have to install synapse on the server and run matrix-appservice-discord or mx-puppet-discord.